### PR TITLE
Fix discover.exs warnings and error

### DIFF
--- a/discover.exs
+++ b/discover.exs
@@ -4,9 +4,13 @@
 Mix.start()
 Mix.target(:host)
 
-Mix.install([
-  {:mndp, "~> 0.1.0", start_applications: false},
-  {:owl, "~> 0.11.0"}
-])
+Mix.install(
+  [
+    {:mndp, "~> 0.1.0"},
+    {:owl, "~> 0.12.0"}
+  ],
+  start_applications: false
+)
 
+Application.ensure_all_started(:owl)
 MNDP.CLI.run()

--- a/discover.exs
+++ b/discover.exs
@@ -9,5 +9,4 @@ Mix.install([
   {:owl, "~> 0.12.0"}
 ])
 
-Application.ensure_all_started(:owl)
 MNDP.CLI.run()

--- a/discover.exs
+++ b/discover.exs
@@ -2,15 +2,12 @@
 
 # Run as host even if invoked with MIX_TARGET set
 Mix.start()
-Mix.target(:host)
+:ok = Mix.target(:host)
 
-Mix.install(
-  [
-    {:mndp, "~> 0.1.0"},
-    {:owl, "~> 0.12.0"}
-  ],
-  start_applications: false
-)
+Mix.install([
+  {:mndp, "~> 0.1.0"},
+  {:owl, "~> 0.12.0"}
+])
 
 Application.ensure_all_started(:owl)
 MNDP.CLI.run()

--- a/lib/mndp/cli.ex
+++ b/lib/mndp/cli.ex
@@ -32,9 +32,8 @@ defmodule MNDP.CLI do
 
   def run() do
     Logger.configure(level: :info)
+    Application.ensure_all_started(:mndp)
     Application.ensure_all_started(:owl)
-    Registry.start_link(keys: :duplicate, name: MNDP.Subscribers)
-    MNDP.Listener.start_link([])
 
     IO.puts("""
 


### PR DESCRIPTION
This gets the discover.exs working again. It had a dependency conflict
with owl and logged a warning due to the `start_applications` parameter
being ignored.
